### PR TITLE
feat(genkit): add multi-model capability with openai

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,66 +1,110 @@
 import { genkit, z } from 'genkit';
-// The CORRECT import for search functionality
 import { vertexAI, gemini15Pro, gemini15Flash } from '@genkit-ai/vertexai';
 import { startFlowServer } from '@genkit-ai/express';
+import { openAI, gpt4o } from 'genkitx-openai'; // Import OpenAI plugin and model
+import { SecretManagerServiceClient } from '@google-cloud/secret-manager'; // Import Secret Manager client
 
-// Configure Genkit to use the Vertex AI plugin.
-// This plugin will automatically use the application's default credentials in Cloud Run.
-// EXPLICITLY set the location to match the Cloud Run deployment region.
-const genkitApp = genkit({
-  plugins: [vertexAI({ location: 'australia-southeast1' })],
-});
+// Instantiate the Secret Manager client
+const secretManager = new SecretManagerServiceClient();
 
-const characterGeneratorFlow = genkitApp.defineFlow(
-  {
-    name: 'characterGeneratorFlow',
-    inputSchema: z.object({ description: z.string() }),
-    outputSchema: z.object({
-      name: z.string(),
-      strength: z.number(),
-      intelligence: z.number(),
-      description: z.string(),
-    }),
-  },
-  async (input) => {
-    const response = await genkitApp.generate({
-      model: gemini15Flash,
-      prompt: `Generate a fantasy character based on this description: ${input.description}. Return ONLY a valid JSON object.`,
-      config: {
-        maxOutputTokens: 256,
-        temperature: 0.1,
-      },
-    });
-
-    try {
-      return JSON.parse(response.text);
-    } catch (parseError) {
-      return { name: "Unknown", strength: 10, intelligence: 10, description: response.text };
+async function getOpenAIKey(): Promise<string> {
+  const secretName = 'projects/vibe-agent-final/secrets/OPENAI_API_KEY/versions/latest';
+  try {
+    const [version] = await secretManager.accessSecretVersion({ name: secretName });
+    const apiKey = version.payload?.data?.toString();
+    if (!apiKey) {
+      throw new Error('OpenAI API key is empty or not found in Secret Manager.');
     }
+    console.log("Successfully loaded OpenAI API key from Secret Manager.");
+    return apiKey;
+  } catch (error) {
+    console.error('Failed to load OpenAI API key from Secret Manager:', error);
+    process.exit(1); // Exit if the key cannot be loaded
   }
-);
+}
 
-const searchAndAnswerFlow = genkitApp.defineFlow(
-  {
-    name: 'searchAndAnswerFlow',
-    inputSchema: z.string(),
-    outputSchema: z.string(),
-  },
-  async (question) => {
-    const response = await genkitApp.generate({
-      model: gemini15Pro,
-      prompt: `Answer the following question using web search results: ${question}`,
-      config: {
-        // This is the correct syntax, and it will work with the vertexAI plugin.
-        googleSearchRetrieval: {},
-        maxOutputTokens: 1000,
-      },
-    });
-    return response.text;
-  }
-);
+// Create a main startup function to handle async initialization
+async function startServer() {
+  const openaiApiKey = await getOpenAIKey();
 
-// Start the production-ready server using the correct Genkit helper.
-startFlowServer({
-  flows: [characterGeneratorFlow, searchAndAnswerFlow],
-  port: parseInt(process.env.PORT || '3400'),
-});
+  const genkitApp = genkit({
+    plugins: [
+      vertexAI({ location: 'australia-southeast1' }),
+      openAI({ apiKey: openaiApiKey }), // Add the initialized OpenAI plugin
+    ],
+  });
+
+  const characterGeneratorFlow = genkitApp.defineFlow(
+    {
+      name: 'characterGeneratorFlow',
+      inputSchema: z.object({ description: z.string() }),
+      outputSchema: z.object({
+        name: z.string(),
+        strength: z.number(),
+        intelligence: z.number(),
+        description: z.string(),
+      }),
+    },
+    async (input) => {
+      const response = await genkitApp.generate({
+        model: gemini15Flash,
+        prompt: `Generate a fantasy character based on this description: ${input.description}. Return ONLY a valid JSON object.`,
+        config: {
+          maxOutputTokens: 256,
+          temperature: 0.1,
+        },
+      });
+
+      try {
+        return JSON.parse(response.text);
+      } catch (parseError) {
+        return { name: "Unknown", strength: 10, intelligence: 10, description: response.text };
+      }
+    }
+  );
+
+  const searchAndAnswerFlow = genkitApp.defineFlow(
+    {
+      name: 'searchAndAnswerFlow',
+      inputSchema: z.string(),
+      outputSchema: z.string(),
+    },
+    async (question) => {
+      const response = await genkitApp.generate({
+        model: gemini15Pro,
+        prompt: `Answer the following question using web search results: ${question}`,
+        config: {
+          googleSearchRetrieval: {},
+          maxOutputTokens: 1000,
+        },
+      });
+      return response.text;
+    }
+  );
+
+  // NEW: A flow specifically to test the OpenAI integration
+  const creativeTextFlow = genkitApp.defineFlow(
+    {
+      name: 'creativeTextFlow',
+      inputSchema: z.string(),
+      outputSchema: z.string(),
+    },
+    async (topic) => {
+      const response = await genkitApp.generate({
+        model: gpt4o, // Use the imported OpenAI model
+        prompt: `Write a short, creative paragraph about: ${topic}`,
+      });
+      return response.text;
+    }
+  );
+  
+  // Start the production-ready server using the correct Genkit helper.
+  // Add the new flow to the list of exposed flows.
+  startFlowServer({
+    flows: [characterGeneratorFlow, searchAndAnswerFlow, creativeTextFlow],
+    port: parseInt(process.env.PORT || '3400'),
+  });
+}
+
+// Run the startup function
+startServer();

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@genkit-ai/vertexai": "^1.15.5",
         "@google-cloud/secret-manager": "^5.5.0",
         "express": "^4.19.2",
-        "genkit": "^1.15.5"
+        "genkit": "^1.15.5",
+        "genkitx-openai": "^0.23.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -3973,6 +3974,18 @@
       },
       "bin": {
         "genkit": "dist/bin/genkit.js"
+      }
+    },
+    "node_modules/genkitx-openai": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/genkitx-openai/-/genkitx-openai-0.23.0.tgz",
+      "integrity": "sha512-vb4fbCkwM51EYgZuJ6yGJKzfTOWXt2n3gyupv0c0eY07eUzPDF4arKc6M1KOSL1jZ7hdaV1nNn+/prt5MEzZmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "openai": "^4.95.0"
+      },
+      "peerDependencies": {
+        "genkit": "^0.9.0 || ^1.0.0"
       }
     },
     "node_modules/get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   },
   "dependencies": {
     "@genkit-ai/express": "^1.15.5",
-    "@genkit-ai/vertexai": "^1.15.5", 
+    "@genkit-ai/vertexai": "^1.15.5",
     "@google-cloud/secret-manager": "^5.5.0",
     "express": "^4.19.2",
-    "genkit": "^1.15.5"
+    "genkit": "^1.15.5",
+    "genkitx-openai": "^0.23.0"
   }
 }


### PR DESCRIPTION
Integrates the 'genkitx-openai' plugin to enable multi-model routing.

- Adds the 'genkitx-openai' dependency.
- Uses the existing 'OPENAI_API_KEY' secret from Secret Manager.
- Updates index.ts to fetch the key and initialize both the Vertex AI and OpenAI plugins on startup.
- Adds a new 'creativeTextFlow' to specifically test the OpenAI integration with the gpt-4o model.